### PR TITLE
Update CubemapToEquirectangular.js

### DIFF
--- a/src/CubemapToEquirectangular.js
+++ b/src/CubemapToEquirectangular.js
@@ -130,7 +130,7 @@ CubemapToEquirectangular.prototype.attachCubeCamera = function( camera ) {
 
 CubemapToEquirectangular.prototype.convert = function( cubeCamera ) {
 
-	this.quad.material.uniforms.map.value = cubeCamera.renderTarget;
+	this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
 	this.renderer.render( this.scene, this.camera, this.output, true );
 
 	var pixels = new Uint8Array( 4 * this.width * this.height );


### PR DESCRIPTION
Avoids warning:
`THREE.WebGLRenderer.setTextureCube: don't use cube render targets as textures. Use their .texture property instead.`
