### PR TITLE
Make downloading the generated image optional

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Jaume Sanchez Elias, http://www.clicktorelease.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build/CubemapToEquirectangular.js
+++ b/build/CubemapToEquirectangular.js
@@ -138,7 +138,7 @@ CubemapToEquirectangular.prototype.attachCubeCamera = function( camera ) {
 
 }
 
-CubemapToEquirectangular.prototype.convert = function( cubeCamera ) {
+CubemapToEquirectangular.prototype.convert = function( cubeCamera, download ) {
 
 	this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
 	this.renderer.render( this.scene, this.camera, this.output, true );
@@ -147,6 +147,16 @@ CubemapToEquirectangular.prototype.convert = function( cubeCamera ) {
 	this.renderer.readRenderTargetPixels( this.output, 0, 0, this.width, this.height, pixels );
 
 	var imageData = new ImageData( new Uint8ClampedArray( pixels ), this.width, this.height );
+
+	if( download !== false ) {
+		this.download( imageData );
+	}
+
+	return imageData
+
+};
+
+CubemapToEquirectangular.prototype.download = function( imageData ) {
 
 	this.ctx.putImageData( imageData, 0, 0 );
 

--- a/src/CubemapToEquirectangular.js
+++ b/src/CubemapToEquirectangular.js
@@ -138,7 +138,7 @@ CubemapToEquirectangular.prototype.attachCubeCamera = function( camera ) {
 
 }
 
-CubemapToEquirectangular.prototype.convert = function( cubeCamera ) {
+CubemapToEquirectangular.prototype.convert = function( cubeCamera, download ) {
 
 	this.quad.material.uniforms.map.value = cubeCamera.renderTarget.texture;
 	this.renderer.render( this.scene, this.camera, this.output, true );
@@ -148,6 +148,16 @@ CubemapToEquirectangular.prototype.convert = function( cubeCamera ) {
 
 	var imageData = new ImageData( new Uint8ClampedArray( pixels ), this.width, this.height );
 
+	if( download !== false ) {
+		this.download( imageData );
+	}
+
+	return imageData
+
+};
+
+CubemapToEquirectangular.prototype.download = function( imageData ) {
+	
 	this.ctx.putImageData( imageData, 0, 0 );
 
 	this.canvas.toBlob( function( blob ) {
@@ -168,7 +178,7 @@ CubemapToEquirectangular.prototype.convert = function( cubeCamera ) {
 
 	}, 'image/png' );
 
-}
+};
 
 CubemapToEquirectangular.prototype.update = function( camera, scene ) {
 


### PR DESCRIPTION
Default behavior have not changed. Added optional argument whether or not to download.
When passing false the convert function will only return the generated ImageData, which can be useful in cases you want to do additional image manipulation or upload the image to a server.